### PR TITLE
feat: polish landing page design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# nova-esports
+# Nova Esports
+
+Sitio web estático para la organización de torneos de League of Legends.
+
+## Desarrollo
+
+El contenido público se encuentra en `dist/`.
+Para visualizar el sitio localmente puedes abrir `dist/index.html` directamente en tu navegador o levantar un servidor con:
+
+```bash
+cd dist
+python -m http.server 8000
+```
+
+Luego visita `http://localhost:8000`.

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Organización profesional de torneos de League of Legends">
+  <title>Nova Esports - Torneos de League of Legends</title>
+  <link rel="stylesheet" href="styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="navbar">
+    <div class="container">
+      <h1 class="logo">Nova Esports</h1>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="#about">Nosotros</a></li>
+          <li><a href="#schedule">Calendario</a></li>
+          <li><a href="#news">Noticias</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="overlay"></div>
+    <div class="hero-content">
+      <h2>La liga más grande de League of Legends</h2>
+      <p>Sigue la emoción semana a semana y demuestra tu nivel en la grieta.</p>
+      <a href="#schedule" class="btn">Ver calendario</a>
+    </div>
+  </section>
+
+  <section id="about" class="section alt">
+    <div class="container about-content">
+      <h2>Sobre Nosotros</h2>
+      <p>En Nova Esports organizamos competiciones de alto nivel para impulsar la escena de League of Legends en la región. Si eres jugador, caster o fan, este es tu lugar.</p>
+      <a href="#schedule" class="btn">Únete</a>
+    </div>
+  </section>
+
+  <section id="schedule" class="section">
+    <div class="container">
+      <h2>Calendario</h2>
+      <div class="schedule-list">
+        <div class="match">
+          <p class="date">12 Jul 2024</p>
+          <p class="teams">Equipo A vs Equipo B</p>
+          <p class="time">18:00 CET</p>
+        </div>
+        <div class="match">
+          <p class="date">19 Jul 2024</p>
+          <p class="teams">Equipo C vs Equipo D</p>
+          <p class="time">20:00 CET</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="news" class="section alt">
+    <div class="container">
+      <h2>Noticias</h2>
+      <div class="news-grid">
+        <article class="news-card">
+          <img src="https://images.unsplash.com/photo-1550745165-9bc0b252726f?auto=format&fit=crop&w=800&q=80" alt="Arena de esports">
+          <h3>Gran final de temporada</h3>
+          <p>Descubre quién se coronó campeón de la última edición.</p>
+        </article>
+        <article class="news-card">
+          <img src="https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80" alt="Jugador concentrado">
+          <h3>Nuevos talentos</h3>
+          <p>Conoce a las promesas que están dominando el circuito.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <p>&copy; 2024 Nova Esports. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/dist/script.js
+++ b/dist/script.js
@@ -1,0 +1,10 @@
+// desplazamiento suave para enlaces internos
+document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+  anchor.addEventListener('click', function (e) {
+    const target = document.querySelector(this.getAttribute('href'));
+    if (target) {
+      e.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+});

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,0 +1,185 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --primary: #6c5ce7;
+  --accent: #00cec9;
+  --light: #ffffff;
+  --muted: #f4f4f4;
+  --text: #333333;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: 'Poppins', sans-serif;
+  background: var(--light);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.container {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.navbar {
+  background: var(--primary);
+  position: fixed;
+  width: 100%;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.logo {
+  font-weight: 600;
+  color: #fff;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 20px;
+}
+
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  transition: color 0.3s;
+}
+
+.nav-links a:hover {
+  color: var(--accent);
+}
+
+.hero {
+  height: 90vh;
+  background: url('https://images.unsplash.com/photo-1508341591423-4347099e1a57?auto=format&fit=crop&w=1950&q=80') center/cover no-repeat;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(108, 92, 231, 0.5);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 700px;
+}
+
+.hero h2 {
+  font-size: 3rem;
+  margin-bottom: 20px;
+}
+
+.btn {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 10px 20px;
+  background: var(--accent);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 4px;
+  transition: background 0.3s;
+}
+
+.btn:hover {
+  background: #00b3ad;
+}
+
+.section {
+  padding: 80px 0;
+}
+
+.section.alt {
+  background: var(--muted);
+}
+
+
+/* Schedule */
+.schedule-list {
+  margin-top: 40px;
+  display: grid;
+  gap: 20px;
+}
+
+.match {
+  background: var(--muted);
+  padding: 20px;
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.match p {
+  margin: 5px 0;
+}
+
+/* News */
+.news-grid {
+  margin-top: 40px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.news-card {
+  background: var(--light);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.news-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.news-card h3 {
+  padding: 15px;
+  font-size: 1.2rem;
+}
+
+.news-card p {
+  padding: 0 15px 20px;
+  font-size: 0.9rem;
+}
+
+.footer {
+  text-align: center;
+  padding: 20px;
+  background: var(--primary);
+  color: #fff;
+}
+
+/* About */
+.about-content {
+  text-align: center;
+  max-width: 800px;
+}
+
+.about-content p {
+  margin: 20px 0;
+}
+


### PR DESCRIPTION
## Summary
- remove contact section and link, focusing on schedule and news
- refresh layout with vibrant purple and teal palette and lighter backgrounds
- keep smooth scrolling script and update about CTA to calendar

## Testing
- `npm test` (fails: Could not read package.json)
- `npm run build` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aa6fd230e083278acc9dd3179ea09a